### PR TITLE
Slowed downed cycling speed

### DIFF
--- a/app/javascript/controllers/typed_js_controller.js
+++ b/app/javascript/controllers/typed_js_controller.js
@@ -7,9 +7,9 @@ export default class extends Controller {
     new Typed(this.element, {
       strings: ["meats", "beef", "pork", "poultry", "lamb"],
       typeSpeed: 70,
-      startDelay: 1200,
+      startDelay: 900,
       backSpeed: 70,
-      backDelay: 900,
+      backDelay: 2000,
       loop: true
     });
   }


### PR DESCRIPTION
The words "meats", "beef", "pork", "poultry", "lamb" now show for 2s before changing to another word. Was previously showing for only 0.9s.