### PR TITLE
excluded products#index from before_action :set_discounted_price & :o…

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,8 +3,8 @@ class ProductsController < ApplicationController
   skip_before_action :authenticate_user!, only: [:index, :show]
 
   before_action :set_butchery, except: [:index, :show]
-  before_action :set_discounted_price, only: [:index, :show]
-  before_action :on_discount?, only: [:index, :show]
+  before_action :set_discounted_price, only: [:show]
+  before_action :on_discount?, only: [:show]
 
   def index
     @products = Product.all


### PR DESCRIPTION
The button to view all products on the homepage was breaking due to the lines in the Product controller to set the expiring products to be discounted:

before_action :set_discounted_price, only: [:index, :show]
before_action :on_discount?, only: [:index, :show]

After excluding :index and changing to:

before_action :set_discounted_price, only: [:show]
before_action :on_discount?, only: [show]

the bug was fixed, and the show all products page (products#index) was still showing products with discounts.